### PR TITLE
Fixed Linux Support

### DIFF
--- a/src/vlcscheduler.py
+++ b/src/vlcscheduler.py
@@ -255,9 +255,9 @@ async def main_coro():
 @click.version_option(version.VERSION)
 def main():
     logger.info('VLC Scheduler v%s started.' % version.VERSION)
-
+    loop = asyncio.new_event_loop()
+   
     if sys.platform == 'win32':
-        loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
 
     try:


### PR DESCRIPTION
"[16:52:33] Traceback (most recent call last):
  File "./vlcscheduler.py", line 264, in main
    loop.run_until_complete(main_coro())
UnboundLocalError: local variable 'loop' referenced before assignment"

the loop declaration on line 260 should be declared in main, not under the win32 platform test. This causes the program to crash on Linux.